### PR TITLE
Updated the name of the scikit-learn dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pandas==1.4.4
 statsmodels
 seaborn
 scipy
-sklearn
+scikit-learn
 gmr
 jupyterlab


### PR DESCRIPTION
The name of `sklearn` has changed to `scikit-learn`, and `sklearn` will no longer work. This updates the `requirements.txt` file to use the updated name